### PR TITLE
fixed dropdown showing behind modal

### DIFF
--- a/src/components/JobCard/JobCard.jsx
+++ b/src/components/JobCard/JobCard.jsx
@@ -236,6 +236,7 @@ export default function JobCard({ job, onDelete, onEdit, onMoveTo, onSelect }) {
                   onChange={(e) => setToStatus(e.target.value)}
                   size="small"
                   sx={jobCardSx.input("var(--panel)")}
+                  MenuProps={{ disablePortal: true }}
                 >
                   {STATUSES.map((s) => (
                     <MenuItem key={s} value={s} disabled={s === fromStatus}>


### PR DESCRIPTION
the dropdown in the Move modal was opening behind the modal instead of on top of it. added disablePortal to fix the rendering position 
@NasBad 