### PR TITLE
fixed columns not fitting the screen

### DIFF
--- a/src/components/StatusColumn/StatusColumn.styles.js
+++ b/src/components/StatusColumn/StatusColumn.styles.js
@@ -1,7 +1,7 @@
 export const statusColumnSx = {
   root: {
-    width: 350,
-    flex: "0 0 350px",
+    flex: 1,
+    minWidth: 220,
     background: "var(--panel)",
     color: "var(--text)",
     border: "1px solid var(--border)",

--- a/src/features/dashboard/KanbanBoard.styles.js
+++ b/src/features/dashboard/KanbanBoard.styles.js
@@ -2,12 +2,9 @@ export const kanbanBoardSx = {
   board: {
     height: "100%",
     width: "100%",
-    maxWidth: 1600,
     display: "flex",
-    gap: 3,
+    gap: 2,
     alignItems: "flex-start",
-    overflowX: { xs: "auto", lg: "hidden" },
     pb: 1.25,
-    justifyContent: { xs: "flex-start", lg: "center" },
   },
 };

--- a/src/pages/Dashboard.styles.js
+++ b/src/pages/Dashboard.styles.js
@@ -6,7 +6,7 @@ export const dashboardPageSx = {
     p: { xs: 1.5, sm: 2 },
     display: "flex",
     flexDirection: "column",
-    alignItems: "center",
+    alignItems: "stretch",
     justifyContent: "flex-start",
     gap: 1.75,
   },


### PR DESCRIPTION
the kanban columns were a fixed width of 350px so they didnt all fit on screen. changed them to flex so they share the available space equally and all 4 columns are always visible

