### PR TITLE
Day 3 - job details panel redesign and list view improvements

### DIFF
--- a/src/components/JobCard/JobCard.jsx
+++ b/src/components/JobCard/JobCard.jsx
@@ -192,7 +192,7 @@ export default function JobCard({ job, onDelete, onEdit, onMoveTo, onSelect }) {
               </Box>
               <Box sx={jobCardSx.field}>
                 <Typography sx={jobCardSx.label}>New Status</Typography>
-                <Select value={toStatus} onChange={(e) => setToStatus(e.target.value)} size="small" sx={jobCardSx.input("var(--panel)")} MenuProps={{ disablePortal: true }}>
+                <Select value={toStatus} onChange={(e) => setToStatus(e.target.value)} size="small" sx={jobCardSx.input("var(--panel)")} MenuProps={{ sx: { zIndex: 1200000 } }}>
                   {STATUSES.map((s) => (
                     <MenuItem key={s} value={s} disabled={s === fromStatus}>{s}</MenuItem>
                   ))}

--- a/src/components/JobCard/JobCard.jsx
+++ b/src/components/JobCard/JobCard.jsx
@@ -194,7 +194,7 @@ export default function JobCard({ job, onDelete, onEdit, onMoveTo, onSelect }) {
                 <Typography sx={jobCardSx.label}>New Status</Typography>
                 <Select value={toStatus} onChange={(e) => setToStatus(e.target.value)} size="small" sx={jobCardSx.input("var(--panel)")} MenuProps={{ sx: { zIndex: 1200000 } }}>
                   {STATUSES.map((s) => (
-                    <MenuItem key={s} value={s} disabled={s === fromStatus}>{s}</MenuItem>
+                    <MenuItem key={s} value={s} disabled={s === fromStatus || (s === "Rejected" && fromStatus === "Wishlist")}>{s}</MenuItem>
                   ))}
                 </Select>
               </Box>

--- a/src/components/JobCard/JobCard.jsx
+++ b/src/components/JobCard/JobCard.jsx
@@ -98,8 +98,13 @@ export default function JobCard({ job, onDelete, onEdit, onMoveTo, onSelect }) {
     setMoveModalOpen(true);
   };
 
+  const moveStatuses = STATUSES.filter(
+    (s) => !(s === "Rejected" && fromStatus === "Wishlist"),
+  );
+
   const confirmMove = () => {
     if (!toStatus || toStatus === fromStatus) return;
+    if (toStatus === "Rejected" && fromStatus === "Wishlist") return;
     if (moveNeedsInterviewing && !moveInterviewDate) return;
     onMoveTo(job.id, toStatus);
     setMoveModalOpen(false);
@@ -193,8 +198,8 @@ export default function JobCard({ job, onDelete, onEdit, onMoveTo, onSelect }) {
               <Box sx={jobCardSx.field}>
                 <Typography sx={jobCardSx.label}>New Status</Typography>
                 <Select value={toStatus} onChange={(e) => setToStatus(e.target.value)} size="small" sx={jobCardSx.input("var(--panel)")} MenuProps={{ sx: { zIndex: 1200000 } }}>
-                  {STATUSES.map((s) => (
-                    <MenuItem key={s} value={s} disabled={s === fromStatus || (s === "Rejected" && fromStatus === "Wishlist")}>{s}</MenuItem>
+                  {moveStatuses.map((s) => (
+                    <MenuItem key={s} value={s} disabled={s === fromStatus}>{s}</MenuItem>
                   ))}
                 </Select>
               </Box>


### PR DESCRIPTION
closes #23
closes #24

redesigned the job details panel to have icons next to each field, renamed the extra section to extra details, made notes editable with a save button, and made the schedule interview button full width.

improved the list view to show company logos next to each row, added an add new button at the bottom of each status group, empty groups now show a dashed border placeholder, and changed the export button to say export excel.

also fixed a bug where rejected could be selected from the wishlist in the move modal.